### PR TITLE
DO NOT USE feat: add macOS support

### DIFF
--- a/fixes/auto-run-fix/patch.js
+++ b/fixes/auto-run-fix/patch.js
@@ -29,7 +29,9 @@ const os = require('os');
 function isAntigravityDir(dir) {
     if (!dir) return false;
     try {
-        const workbench = path.join(dir, 'resources', 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js');
+        // macOS uses 'Resources' (capital R), Windows/Linux use 'resources'
+        const res = process.platform === 'darwin' ? 'Resources' : 'resources';
+        const workbench = path.join(dir, res, 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js');
         return fs.existsSync(workbench);
     } catch { return false; }
 }
@@ -123,8 +125,8 @@ function findAntigravityPath() {
         );
     } else if (process.platform === 'darwin') {
         candidates.push(
-            '/Applications/Antigravity.app/Contents/Resources',
-            path.join(os.homedir(), 'Applications', 'Antigravity.app', 'Contents', 'Resources')
+            '/Applications/Antigravity.app/Contents',
+            path.join(os.homedir(), 'Applications', 'Antigravity.app', 'Contents')
         );
     } else {
         candidates.push('/usr/share/antigravity', '/opt/antigravity',
@@ -324,8 +326,9 @@ function checkFile(filePath, label) {
 
 function getVersion(basePath) {
     try {
-        const pkg = JSON.parse(fs.readFileSync(path.join(basePath, 'resources', 'app', 'package.json'), 'utf8'));
-        const product = JSON.parse(fs.readFileSync(path.join(basePath, 'resources', 'app', 'product.json'), 'utf8'));
+        const res = process.platform === 'darwin' ? 'Resources' : 'resources';
+        const pkg = JSON.parse(fs.readFileSync(path.join(basePath, res, 'app', 'package.json'), 'utf8'));
+        const product = JSON.parse(fs.readFileSync(path.join(basePath, res, 'app', 'product.json'), 'utf8'));
         return `${pkg.version} (IDE ${product.ideVersion})`;
     } catch { return 'unknown'; }
 }
@@ -375,9 +378,15 @@ function main() {
     console.log(`📦 Version: ${getVersion(basePath)}`);
     console.log('');
 
+    const res = process.platform === 'darwin' ? 'Resources' : 'resources';
     const files = [
-        { path: path.join(basePath, 'resources', 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js'), label: 'workbench' },
-        { path: path.join(basePath, 'resources', 'app', 'out', 'jetskiAgent', 'main.js'), label: 'jetskiAgent' },
+        { path: path.join(basePath, res, 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js'), label: 'workbench' },
+        // macOS: jetskiAgent lives under vs/code/electron-browser/workbench/
+        // Windows: jetskiAgent lives under jetskiAgent/
+        ...(process.platform === 'darwin'
+            ? [{ path: path.join(basePath, res, 'app', 'out', 'vs', 'code', 'electron-browser', 'workbench', 'jetskiAgent.js'), label: 'jetskiAgent' }]
+            : [{ path: path.join(basePath, res, 'app', 'out', 'jetskiAgent', 'main.js'), label: 'jetskiAgent' }]
+        ),
     ];
 
     switch (action) {

--- a/src/auto-run.ts
+++ b/src/auto-run.ts
@@ -12,30 +12,70 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
+import * as os from 'os';
 
 /** Marker comment to identify our patches */
 const PATCH_MARKER = '/*BA:autorun*/';
 
 /**
- * Resolve the Antigravity workbench directory.
+ * Resolve the Antigravity base installation directory.
+ *
+ * Returns the directory that contains the resources/app structure.
+ * On Windows this is e.g. LOCALAPPDATA/Programs/Antigravity,
+ * on macOS this is /Applications/Antigravity.app/Contents.
  */
 export function getWorkbenchDir(): string | null {
-    const appData = process.env.LOCALAPPDATA || '';
-    const dir = path.join(
-        appData,
-        'Programs', 'Antigravity', 'resources', 'app', 'out',
-        'vs', 'code', 'electron-browser', 'workbench',
-    );
-    return fs.existsSync(dir) ? dir : null;
+    const candidates: string[] = [];
+
+    if (process.platform === 'darwin') {
+        // macOS: standard .app bundle locations
+        candidates.push(
+            '/Applications/Antigravity.app/Contents',
+            path.join(os.homedir(), 'Applications', 'Antigravity.app', 'Contents'),
+        );
+    } else if (process.platform === 'win32') {
+        // Windows: standard install locations
+        candidates.push(
+            path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Antigravity'),
+        );
+    } else {
+        // Linux: common locations
+        candidates.push(
+            '/usr/share/antigravity',
+            '/opt/antigravity',
+            path.join(os.homedir(), '.local', 'share', 'antigravity'),
+        );
+    }
+
+    // The "resources" directory is capitalised on macOS ('Resources')
+    const resourcesDir = process.platform === 'darwin' ? 'Resources' : 'resources';
+
+    for (const base of candidates) {
+        const check = path.join(base, resourcesDir, 'app', 'out', 'vs', 'workbench', 'workbench.desktop.main.js');
+        if (fs.existsSync(check)) return base;
+    }
+    return null;
 }
 
 /**
  * Target files that need the auto-run patch.
+ *
+ * On Windows both files live under a single workbench directory.
+ * On macOS they are in different subdirectories of the app bundle,
+ * so we resolve each target independently.
  */
-export function getTargetFiles(workbenchDir: string): Array<{ path: string; label: string }> {
+export function getTargetFiles(baseDir: string): Array<{ path: string; label: string }> {
+    const res = process.platform === 'darwin' ? 'Resources' : 'resources';
+    const appOut = path.join(baseDir, res, 'app', 'out');
+
     return [
-        { path: path.join(workbenchDir, 'workbench.desktop.main.js'), label: 'workbench' },
-        { path: path.join(workbenchDir, 'jetskiAgent.js'), label: 'jetskiAgent' },
+        { path: path.join(appOut, 'vs', 'workbench', 'workbench.desktop.main.js'), label: 'workbench' },
+        // macOS: jetskiAgent lives under vs/code/electron-browser/workbench/
+        // Windows: jetskiAgent lives under jetskiAgent/
+        ...(process.platform === 'darwin'
+            ? [{ path: path.join(appOut, 'vs', 'code', 'electron-browser', 'workbench', 'jetskiAgent.js'), label: 'jetskiAgent' }]
+            : [{ path: path.join(appOut, 'jetskiAgent', 'main.js'), label: 'jetskiAgent' }]
+        ),
     ].filter(f => fs.existsSync(f.path));
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -58,12 +58,22 @@ export async function revertAutoRun(): Promise<void> {
 
     if (reverted > 0) {
         // Clear V8 Code Cache — stale cache after revert causes grey screen
-        const appData = process.env.APPDATA || '';
-        const cacheDirs = [
-            path.join(appData, 'Antigravity', 'CachedData'),
-            path.join(appData, 'Antigravity', 'GPUCache'),
-            path.join(appData, 'Antigravity', 'Code Cache'),
-        ];
+        const cacheDirs: string[] = [];
+        if (process.platform === 'darwin') {
+            const appSupport = path.join(process.env.HOME || '', 'Library', 'Application Support', 'Antigravity');
+            cacheDirs.push(
+                path.join(appSupport, 'CachedData'),
+                path.join(appSupport, 'GPUCache'),
+                path.join(appSupport, 'Code Cache'),
+            );
+        } else {
+            const appData = process.env.APPDATA || '';
+            cacheDirs.push(
+                path.join(appData, 'Antigravity', 'CachedData'),
+                path.join(appData, 'Antigravity', 'GPUCache'),
+                path.join(appData, 'Antigravity', 'Code Cache'),
+            );
+        }
         for (const d of cacheDirs) {
             try { await fsp.rm(d, { recursive: true, force: true }); } catch { /* may not exist */ }
         }


### PR DESCRIPTION
## 🍎 macOS Support Implementation

This PR adds full support for macOS path detection and cache management. Since Antigravity on macOS uses a different bundle structure and different resource directory naming conventions (capitalized 'Resources'), the extension was previously failing to initialize.

### 🛠️ Changes included:

**1. Cross-Platform Path Detection ()**
- Updated `getWorkbenchDir()` to handle macOS `.app` bundle paths (`/Applications/Antigravity.app/Contents`).
- Improved `getTargetFiles()` to resolve each file independently, accounting for the different subdirectory structures on macOS vs Windows.
- Added platform-aware resource directory naming (`Resources` on macOS vs `resources` on Windows/Linux).

**2. CLI Patcher Updates (`fixes/auto-run-fix/patch.js`)**
- Fixed bundle candidate paths for macOS.
- Updated `getVersion()` to correctly locate `package.json` and `product.json` on macOS.
- Implemented macOS-specific subpaths for `jetskiAgent.js`.

**3. Cache Clearing (`src/commands.ts`)**
- Added macOS cache directory paths (`~/Library/Application Support/Antigravity/`) to the `revertAutoRun` command.

---

### 📝 Note on `jetskiAgent.js` on macOS
During testing on macOS (v1.107.0 / IDE 1.19.6), we observed that `jetskiAgent.js` is a tiny bootstrap shim (~19KB) and does not contain the `run_command` renderer pattern. The relevant UI code on macOS appears to be bundled entirely within `workbench.desktop.main.js`. 

The patcher correctly identifies this and skips `jetskiAgent.js` without erroring, as the fix is fully covered by the workbench patch.

Tested on macOS (Apple Silicon). Fixes initialization errors and enables Chat Rename and Auto-Run patches.