### PR TITLE
fix: correct insertion point for v1.21.6+ comma-chained declarations

### DIFF
--- a/fixes/auto-run-fix/patch.js
+++ b/fixes/auto-run-fix/patch.js
@@ -236,11 +236,17 @@ function analyzeFile(content, label) {
     }
     console.log(`     useEffect=${useEffectAlias}`);
 
-    // 5. Insertion point: after useCallback closing `])`, then after the `;`
+    // 5. Insertion point: AFTER the `;` that terminates the let/var chain
+    //    In v1.21.6+ the minifier comma-chains ALL declarations into one `let`,
+    //    so the terminating `;` is hundreds of chars after the onChange `])`.
+    //    We must insert AFTER that `;` (between the let statement and `return`).
+    //    In older versions where each declaration ends with its own `;`, the
+    //    first `;` is right after `])` — same logic works in both cases.
     const afterOnChange = content.indexOf('])', insertPos);
     if (afterOnChange === -1) return null;
-    const insertAt = content.indexOf(';', afterOnChange);
-    if (insertAt === -1) return null;
+    const chainSemicolon = content.indexOf(';', afterOnChange);
+    if (chainSemicolon === -1) return null;
+    const insertAt = chainSemicolon + 1; // insert AFTER the ;
 
     return { enumAlias, confirmFn, policyVar, secureVar, useEffectAlias, insertAt };
 }


### PR DESCRIPTION
## Summary

Fixes the auto-run patch bricking Antigravity on v1.21.6+ (black panels, app hang). The regex matching is fine — the bug is in the **insertion point logic**.

Resolves #22

## Root Cause

In AG v1.21.6, the minifier changed how variable declarations are structured. Previously, each `useCallback`/`useMemo` was its own statement:

```javascript
let v = Zt(B=>{...},[r,b]);  // ← semicolon right here
let E = Zt(()=>{...},[b]);
```

In v1.21.6+, the minifier **comma-chains** ALL declarations into a single `let`:

```javascript
let r=Ot(...),...,S=tt(W=>{...},[o,E]),I=tt(...),...,O=Ot(...),[F,u,k,V]);return D(...)
```

The patcher's insertion logic was:
1. Find the `])` closing the onChange handler's dependency array ✅
2. Find the next `;` after that ❌ — now **426 chars away** (at the end of the entire let chain)
3. Insert the patch **before** that `;` ❌ — this placed the `useEffect` call **inside the let declaration**, producing a `SyntaxError`

### Before (BROKEN)
```
let ...,O=Ot(...),[F,u,k,V])/*BA:autorun*/useEffect(...)[];return D(...)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                             Inside let declaration = SyntaxError!
```

### After (FIXED)
```
let ...,O=Ot(...),[F,u,k,V]);/*BA:autorun*/useEffect(...)[];return D(...)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              Standalone statement between let and return = valid JS
```

## The Fix

**One-line change**: insert AFTER the chain-terminating `;` instead of before it (`chainSemicolon + 1` instead of `chainSemicolon`).

This works for **both** old and new AG versions:
- **Old versions** (semicolon-separated): the first `;` is right after `])`, so `insertAt` lands between statements — correct
- **New versions** (comma-chained): the first `;` is at the end of the full chain, so `insertAt` lands between the let statement and `return` — also correct

## Testing

Tested on AG v1.107.0 (IDE 1.21.6) on Windows:
- ✅ `--check` correctly identifies both `workbench` and `jetskiAgent` as patchable
- ✅ Patch applies cleanly to both files (+51 bytes each)
- ✅ Antigravity starts without black screen / hang
- ✅ Terminal commands auto-execute with "Always Proceed" setting
- ✅ `--revert` cleanly restores original files
- ✅ `jetskiAgent-legacy` gracefully reports pattern not found (expected)

## Changes

| File | Change |
|------|--------|
| `fixes/auto-run-fix/patch.js` | Insert AFTER `;` instead of before it (line 249: `chainSemicolon + 1`) |